### PR TITLE
Drop Python 3.9 support and adapt SPEC 0 standard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout Repository  

--- a/docs/dev-guide/introduction.rst
+++ b/docs/dev-guide/introduction.rst
@@ -185,3 +185,9 @@ Type Hinting
 Rodhaj actively uses `type hinting <https://docs.python.org/3/library/typing.html>`_ in order to verify for types before runtime.
 `Pyright <https://github.com/microsoft/pyright>`_ is used to enforce this standard. Checks happen before you commit, and on Github actions.
 These checks are activated by default on VSCode. Pyright is available as a LSP on Neovim.
+
+Minimum supported Python versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rodhaj implements the `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`_ standard. 
+Spefically, Python versions over **3 years** are dropped after initial release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "rodhaj"
 version = "0.3.1"
 description = "A improved, modern version of ModMail for Transprogrammer"
 license = {file = "LICENSE"}
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 
 [tool.pyright]
 include = ["bot/**"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311,312,313}
+env_list = py{310,311,312,313}
 no_package = true
 
 [testenv]


### PR DESCRIPTION
# Summary

As title states. Drops support for Python 3.9, and any other prep that is required for this change.

## Types of changes

What types of changes does your code introduce to Rodhaj?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
