### PR TITLE
Migrate workflows to Ubuntu 24.04 labels

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -4,11 +4,11 @@ on: pull_request_target
 
 jobs:
   auto-approve:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: hmarr/auto-approve-action@v3
+      - uses: hmarr/auto-approve-action@v4
         with:
             github-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   Analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor == 'dependabot[bot]'}}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Build-and-Push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # We want to filter out dependabot and pre-commit
     # automated pushes to main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  Analyze:
+  check:
     runs-on: ubuntu-24.04
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   Bundle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: contains(github.event.head_commit.message, '#major') || contains(github.event.head_commit.message, '#minor') || contains(github.event.head_commit.message, '#patch')
     steps:
       - name: Checkout Repository
@@ -31,7 +31,7 @@ jobs:
   
 
   Release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: Bundle
     if: contains(github.event.head_commit.message, '#major') || contains(github.event.head_commit.message, '#minor') || contains(github.event.head_commit.message, '#patch')
     steps:


### PR DESCRIPTION
# Summary

Due to breaking changes by GH ([details](https://github.com/actions/runner-images/issues/10636)), we need to migrate from the `ubuntu-latest` label to `ubuntu-24.04`. This label should contain upgraded tools as well.

## Types of changes

What types of changes does your code introduce to Rodhaj?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
